### PR TITLE
Release 4.2.0

### DIFF
--- a/clutch/client.py
+++ b/clutch/client.py
@@ -32,3 +32,19 @@ class Client:
 
     def set_rpc_debug(self, value: bool):
         self._connection.debug = value
+
+    def set_connection(
+        self,
+        address="http://localhost:9091/transmission/rpc",
+        scheme=None,
+        host=None,
+        port=None,
+        path=None,
+        query=None,
+        username=None,
+        password=None,
+        debug=False,
+    ):
+        self._endpoint = make_endpoint(address, scheme, host, port, path, query)
+        self._session = TransmissionSession(username, password)
+        self._connection = Connection(self._endpoint, self._session, debug)

--- a/clutch/network/connection.py
+++ b/clutch/network/connection.py
@@ -20,12 +20,12 @@ class Connection:
     def send(self, request: Request, model: Type[T] = None) -> Response[T]:
         data = request.json(by_alias=True, exclude_none=True).encode("utf-8")
         if self.debug:
-            print("RPC request:")
+            print(f"RPC request sent to {self.endpoint}:")
             print(data)
         response = self.session.post(self.endpoint, data=data)
         if model is not None:
             if self.debug:
-                print("RPC response:")
+                print("RPC response received:")
                 print(response.text)
             return Response[model].parse_raw(response.text)  # type: ignore
         else:

--- a/clutch/schema/user/method/session/accessor.py
+++ b/clutch/schema/user/method/session/accessor.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from clutch.compat import Literal
 
 
 SessionAccessorField = Literal[

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = "2020, Michael Hadam"
 author = "Michael Hadam"
 
 # The full version, including alpha/beta/rc tags
-release = "4.1.0"
+release = "4.2.0"
 
 # -- General configuration ---------------------------------------------------
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -248,11 +248,11 @@ socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [[package]]
 category = "dev"
-description = "Measures number of Terminal column cells of wide-character codes"
+description = "Measures the displayed width of unicode strings in a terminal"
 name = "wcwidth"
 optional = false
 python-versions = "*"
-version = "0.1.9"
+version = "0.2.2"
 
 [[package]]
 category = "dev"
@@ -404,8 +404,8 @@ urllib3 = [
     {file = "urllib3-1.25.9.tar.gz", hash = "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527"},
 ]
 wcwidth = [
-    {file = "wcwidth-0.1.9-py2.py3-none-any.whl", hash = "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1"},
-    {file = "wcwidth-0.1.9.tar.gz", hash = "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"},
+    {file = "wcwidth-0.2.2-py2.py3-none-any.whl", hash = "sha256:b651b6b081476420e4e9ae61239ac4c1b49d0c5ace42b2e81dc2ff49ed50c566"},
+    {file = "wcwidth-0.2.2.tar.gz", hash = "sha256:3de2e41158cb650b91f9654cbf9a3e053cee0719c9df4ddc11e4b568669e9829"},
 ]
 zipp = [
     {file = "zipp-3.1.0-py3-none-any.whl", hash = "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "transmission-clutch"
-version = "4.1.0"
+version = "4.2.0"
 description = "An RPC client library for the Transmission BitTorrent client"
 authors = ["mhadam <michael@hadam.us>"]
 repository = "https://github.com/mhadam/clutch"


### PR DESCRIPTION
* outputs the endpoint with RPC debug messages
* adds a method for setting a new connection on a client object
* fixes a mistaken import for `Literal`