### PR TITLE
Fix tracker_remove argument type

### DIFF
--- a/clutch/schema/request/torrent/mutator.py
+++ b/clutch/schema/request/torrent/mutator.py
@@ -34,7 +34,7 @@ class TorrentMutatorArgumentsRequest(BaseModel):
     seed_ratio_limit: Optional[float] = Field(None, alias="seedRatioLimit")
     seed_ratio_mode: Optional[int] = Field(None, alias="seedRatioMode")
     tracker_add: Optional[Sequence[str]] = Field(None, alias="trackerAdd")
-    tracker_remove: Optional[Sequence[str]] = Field(None, alias="trackerRemove")
+    tracker_remove: Optional[Sequence[int]] = Field(None, alias="trackerRemove")
     tracker_replace: Optional[Sequence[TrackerReplaceRequest]] = Field(
         None, alias="trackerReplace"
     )

--- a/clutch/schema/user/method/torrent/mutator.py
+++ b/clutch/schema/user/method/torrent/mutator.py
@@ -30,7 +30,7 @@ class TorrentMutatorArguments(TypedDict, total=False):
     seed_ratio_limit: float
     seed_ratio_mode: int
     tracker_add: Sequence[str]
-    tracker_remove: Sequence[str]
+    tracker_remove: Sequence[int]
     tracker_replace: Sequence[TrackerReplace]
     upload_limit: int
     upload_limited: bool


### PR DESCRIPTION
The API expects a list of int ids for trackerRemove.
Now it gets a list of strings and the call fails